### PR TITLE
Fixes /etc issuesfor V5520.2053.0379build20220208

### DIFF
--- a/scripts/pack_fw.sh
+++ b/scripts/pack_fw.sh
@@ -87,6 +87,7 @@ STATIC_DIR=$BASE_DIR/static
 BUILD_DIR=$BASE_DIR/build
 OUT_DIR=$BASE_DIR/out/$CAMERA_NAME
 VER=$(cat VERSION)
+CROSSLINK_SYSROOT=$(dirname $(dirname $(which arm-sonoff-linux-uclibcgnueabi-gcc)))/arm-sonoff-linux-uclibcgnueabi/sysroot
 
 echo ""
 echo "------------------------------------------------------------------------"
@@ -117,6 +118,11 @@ mkdir -p ${TMP_DIR}/sonoff-hack
 # copy the build files to the tmp dir
 echo -n ">>> Copying files from the build directory to ${TMP_DIR}... "
 cp -R $BUILD_DIR/sonoff-hack/* $TMP_DIR/sonoff-hack || exit 1
+echo "done!"
+
+# copy files from crosslink sysroot to the temp dir
+echo -n ">>> Copying files from the crosslink sysroot directory to ${TMP_DIR}... "
+cp $CROSSLINK_SYSROOT/lib/libcrypt.so.0 $TMP_DIR/sonoff-hack/lib || exit 1
 echo "done!"
 
 # rename binaries based on camera name

--- a/sdhack/boot.sh
+++ b/sdhack/boot.sh
@@ -7,9 +7,12 @@ touch /tmp/di.wav
 touch /tmp/Internet_connected_Welcome_to_use_cloud_camera.wav
 touch /tmp/WiFi_connect_success.wav
 
-mount --bind /tmp/di.wav /mnt/mtd/ipc/app/res/En/di.wav
-mount --bind /tmp/Internet_connected_Welcome_to_use_cloud_camera.wav /mnt/mtd/ipc/app/res/En/Internet_connected_Welcome_to_use_cloud_camera.wav
-mount --bind /tmp/WiFi_connect_success.wav /mnt/mtd/ipc/app/res/En/WiFi_connect_success.wav
+WAV_FILE_DIR=/mnt/mtd/ipc/app/res/En
+[ -d /mnt/mtd/ipc/app/snd/english ] && WAV_FILE_DIR=/mnt/mtd/ipc/app/snd/english
+
+mount --bind /tmp/di.wav $WAV_FILE_DIR/di.wav
+mount --bind /tmp/Internet_connected_Welcome_to_use_cloud_camera.wav $WAV_FILE_DIR/Internet_connected_Welcome_to_use_cloud_camera.wav
+mount --bind /tmp/WiFi_connect_success.wav $WAV_FILE_DIR/WiFi_connect_success.wav
 
 # Fix hostname
 cp /mnt/mtd/ipc/app/script/dhcp.sh /tmp/dhcp.sh

--- a/src/static/static/sonoff-hack/script/system.sh
+++ b/src/static/static/sonoff-hack/script/system.sh
@@ -6,7 +6,9 @@ SONOFF_HACK_PREFIX="/mnt/mmc/sonoff-hack"
 SONOFF_HACK_UPGRADE_PATH="/mnt/mmc/.fw_upgrade"
 
 SONOFF_HACK_VER=$(cat /mnt/mmc/sonoff-hack/version)
-MODEL=$(cat /mnt/mtd/ipc/cfg/config_cst.cfg | grep model | cut -d'=' -f2 | cut -d'"' -f2)
+MODEL_CFG_FILE=/mnt/mtd/ipc/cfg/config_cst.cfg
+[ -f /mnt/mtd/db/conf/config_cst.ini ] && MODEL_CFG_FILE=/mnt/mtd/db/conf/config_cst.ini
+MODEL=$(cat $MODEL_CFG_FILE | grep model | cut -d'=' -f2 | cut -d'"' -f2)
 DEVICE_ID=$(cat /mnt/mtd/ipc/cfg/colink.conf | grep devid | cut -d'=' -f2 | cut -d'"' -f2)
 
 get_config()

--- a/src/static/static/sonoff-hack/script/system.sh
+++ b/src/static/static/sonoff-hack/script/system.sh
@@ -45,8 +45,8 @@ fi
 
 $SONOFF_HACK_PREFIX/script/check_conf.sh
 
-cp -f $SONOFF_HACK_PREFIX/etc/hostname /etc/hostname
-hostname -F /etc/hostname
+mount -o bind $SONOFF_HACK_PREFIX/etc/hostname /etc/hostname
+hostname -F $SONOFF_HACK_PREFIX/etc/hostname
 export TZ=$(get_config TIMEZONE)
 
 if [[ $(get_config SWAP_FILE) == "yes" ]] ; then
@@ -125,17 +125,14 @@ else
     RTSP_USERPWD="hack:hack@"
 fi
 
-cp -f $SONOFF_HACK_PREFIX/etc/passwd /etc/passwd
-cp -f $SONOFF_HACK_PREFIX/etc/shadow /etc/shadow
 PASSWORD_MD5='$1$$qRPK7m23GJusamGpoGLby/'
 if [[ x$(get_config SSH_PASSWORD) != "x" ]] ; then
     SSH_PASSWORD=$(get_config SSH_PASSWORD)
     PASSWORD_MD5="$(echo "${SSH_PASSWORD}" | mkpasswd --method=MD5 --stdin)"
 fi
-CUR_PASSWORD_MD5=$(awk -F":" '$1 == "root" { print $2 } ' /etc/shadow)
-if [[ x$CUR_PASSWORD_MD5 != x$PASSWORD_MD5 ]] ; then
-    sed -i 's|^\(root:\)[^:]*:|root:'${PASSWORD_MD5}':|g' "/etc/shadow"
-fi
+sed -i 's|^\(root:\)[^:]*:|root:'${PASSWORD_MD5}':|g' "$SONOFF_HACK_PREFIX/etc/shadow"
+mount -o bind $SONOFF_HACK_PREFIX/etc/passwd /etc/passwd
+mount -o bind $SONOFF_HACK_PREFIX/etc/shadow /etc/shadow
 
 case $(get_config RTSP_PORT) in
     ''|*[!0-9]*) RTSP_PORT=554 ;;
@@ -159,6 +156,8 @@ if [[ $(get_config PTZ_PRESET_BOOT) != "default" ]] ; then
 fi
 
 if [[ $(get_config DISABLE_CLOUD) == "yes" ]] ; then
+    cp /etc/hosts /tmp
+    mount -o bind /tmp/hosts /etc/hosts
     # Add forbidden domains
     echo "127.0.0.1               eu-dispd.coolkit.cc" >> /etc/hosts
     echo "127.0.0.1               eu-api.coolkit.cn" >> /etc/hosts
@@ -211,11 +210,7 @@ if [[ $(get_config SSHD) == "yes" ]] ; then
         dropbearkey -t ecdsa -f /tmp/dropbear_ecdsa_host_key
         mv /tmp/dropbear_ecdsa_host_key $SONOFF_HACK_PREFIX/etc/dropbear/
     fi
-    # Restore keys
-    mkdir -p /etc/dropbear
-    cp -f $SONOFF_HACK_PREFIX/etc/dropbear/* /etc/dropbear/
-    chmod 0600 /etc/dropbear/*
-    dropbear -R
+    dropbear -E -r $SONOFF_HACK_PREFIX/etc/dropbear/dropbear_ecdsa_host_key
 fi
 
 if [[ $(get_config NTPD) == "yes" ]] ; then

--- a/src/static/static/sonoff-hack/script/system.sh
+++ b/src/static/static/sonoff-hack/script/system.sh
@@ -186,6 +186,7 @@ else
     umount /mnt/mtd/ipc/app/colink
     rm /tmp/colink
 fi
+[ $(ps | grep '/mnt/mtd/ipc/app/rtspd' | grep -v grep | grep -c ^) -eq 0 ] && /mnt/mtd/ipc/app/rtspd &
 
 if [[ $(get_config HTTPD) == "yes" ]] ; then
     mkdir -p /mnt/mmc/alarm_record

--- a/src/static/static/sonoff-hack/script/system.sh
+++ b/src/static/static/sonoff-hack/script/system.sh
@@ -47,7 +47,7 @@ fi
 
 $SONOFF_HACK_PREFIX/script/check_conf.sh
 
-mount -o bind $SONOFF_HACK_PREFIX/etc/hostname /etc/hostname
+cp -f $SONOFF_HACK_PREFIX/etc/hostname /etc/hostname
 hostname -F $SONOFF_HACK_PREFIX/etc/hostname
 export TZ=$(get_config TIMEZONE)
 

--- a/src/www/httpd/cgi-bin/status.json
+++ b/src/www/httpd/cgi-bin/status.json
@@ -2,11 +2,14 @@
 
 printf "Content-type: application/json\r\n\r\n"
 
+MODEL_CFG_FILE=/mnt/mtd/ipc/cfg/config_cst.cfg
+[ -f /mnt/mtd/db/conf/config_cst.ini ] && MODEL_CFG_FILE=/mnt/mtd/db/conf/config_cst.ini
+
 NAME="sonoff-hack"
 HOSTNAME=$(hostname)
 FW_VERSION=$(cat /mnt/mmc/sonoff-hack/version)
 HOME_VERSION=$(cat /mnt/mtd/ipc/cfg/version)
-MODEL=$(cat /mnt/mtd/ipc/cfg/config_cst.cfg | grep model | cut -d'=' -f2 | cut -d'"' -f2)
+MODEL=$(cat $MODEL_CFG_FILE | grep model | cut -d'=' -f2 | cut -d'"' -f2)
 PTZ="yes"
 SERIAL_NUMBER=$(cat /mnt/mtd/ipc/cfg/colink.conf | grep devid | cut -d "=" -f2 | cut -d'"' -f2)
 DEVICE_ID=$(cat /mnt/mtd/ipc/cfg/colink.conf | grep devid | cut -d "=" -f2 | cut -d'"' -f2)

--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -195,8 +195,8 @@ APP.ptz = (function($) {
             dataType: "json",
             success: function(data) {
                 for (let key in data) {
-                    if (key == "model") {
-                        if ((data[key] == "GK-200MP2B") || (data[key] == "GK-200MP2C")) {
+                    if (key == "ptz") {
+                        if (data[key] == "yes") {
                             $('#ptz_description').show();
                             $('#ptz_available').hide();
                             $('#ptz_main').show();


### PR DESCRIPTION
This pull request fixes some issues with V5520.2053.0379build20220208:

- `/etc` is no longer writable
- wav files are in a different location
- the file for reading the model string has been changed

All of these changes should not change the behavior in previous firmware versions.

There are other not yet addressed issues (see also #85):
- Model string is different (before "GK-200MP2B" now "GK-200MP2-B")
- `libcrypt.so.0` is missing (need to be compiled from openssl?)
- `libhardware.so` or `libptz.so` is missing and no other lib to control the ptz is included
