### PR TITLE
Make scp actually work

### DIFF
--- a/src/dropbear/install.dropbear
+++ b/src/dropbear/install.dropbear
@@ -17,7 +17,8 @@ echo "#!/mnt/mmc/sonoff-hack/bin/dropbearmulti" > ../../build/sonoff-hack/bin/dr
 chmod 0755 ../../build/sonoff-hack/bin/dropbearconvert
 echo "#!/mnt/mmc/sonoff-hack/bin/dropbearmulti" > ../../build/sonoff-hack/bin/dropbearkey
 chmod 0755 ../../build/sonoff-hack/bin/dropbearkey
-echo "#!/mnt/mmc/sonoff-hack/bin/dropbearmulti" > ../../build/sonoff-hack/bin/scp
+echo "#!/bin/sh" > ../../build/sonoff-hack/bin/scp
+echo 'LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/mnt/mtd/ipc/app/lib:/mnt/mmc/sonoff-hack/lib /mnt/mmc/sonoff-hack/bin/dropbearmulti scp $@' >> ../../build/sonoff-hack/bin/scp
 chmod 0755 ../../build/sonoff-hack/bin/scp
 echo "#!/mnt/mmc/sonoff-hack/bin/dropbearmulti" > ../../build/sonoff-hack/bin/ssh
 chmod 0755 ../../build/sonoff-hack/bin/ssh

--- a/src/dropbear/localoptions.h
+++ b/src/dropbear/localoptions.h
@@ -8,6 +8,7 @@
 
 #define DROPBEAR_PATH_SSH_PROGRAM "/mnt/mmc/sonoff-hack/bin/dbclient"
 
-#define DEFAULT_PATH "/usr/bin:/usr/sbin:/bin:/sbin:/gm/bin:/gm/tools:/mnt/mmc/sonoff-hack/bin:/mnt/mmc/sonoff-hack/sbin:/mnt/mmc/sonoff-hack/usr/bin:/mnt/mmc/sonoff-hack/usr/sbin"
+#define DEFAULT_PATH "/usr/bin:/bin:/gm/bin:/gm/tools:/mnt/mmc/sonoff-hack/bin:/mnt/mmc/sonoff-hack/usr/bin"
+#define DEFAULT_ROOT_PATH "/usr/bin:/usr/sbin:/bin:/sbin:/gm/bin:/gm/tools:/mnt/mmc/sonoff-hack/bin:/mnt/mmc/sonoff-hack/sbin:/mnt/mmc/sonoff-hack/usr/bin:/mnt/mmc/sonoff-hack/usr/sbin"
 
 #endif /* DROPBEAR_LOCALOPTIONS_H */


### PR DESCRIPTION
This will fix the not working scp function of dropbear.

1. It correctly sets the `PATH` environment variable for the root user in order to find the `scp` command.
2. It changes the `LD_LIBRARY_PATH` environment variable in order to find `libcrypt.so.0`.

BTW: `scp` is deprecated by openSSH in favor of `sftp`, you may need to use `scp -O` on the host.