### PR TITLE
Only setup PTZ if kernel module is loaded

### DIFF
--- a/src/static/static/sonoff-hack/script/system.sh
+++ b/src/static/static/sonoff-hack/script/system.sh
@@ -148,11 +148,14 @@ case $(get_config HTTPD_PORT) in
 esac
 
 # Restart ptz driver
-rmmod ptz_drv.ko
-sleep 1
-insmod /mnt/mtd/ipc//app/drive/ptz_drv.ko factory="Links" AutoRun=1 Horizontal=3500 Vertical=900
-if [[ $(get_config PTZ_PRESET_BOOT) != "default" ]] ; then
-    (sleep 20 && /mnt/mmc/sonoff-hack/bin/ptz -a go_preset -f $SONOFF_HACK_PREFIX/etc/ptz_presets.conf -n $(get_config PTZ_PRESET_BOOT)) &
+PTZ_PRESENT=$(cat /proc/modules | grep ptz_drv | grep -c ^)
+if [[ $PTZ_PRESENT -eq 1 ]]; then
+    rmmod ptz_drv.ko
+    sleep 1
+    insmod /mnt/mtd/ipc//app/drive/ptz_drv.ko factory="Links" AutoRun=1 Horizontal=3500 Vertical=900
+    if [[ $(get_config PTZ_PRESET_BOOT) != "default" ]] ; then
+        (sleep 20 && /mnt/mmc/sonoff-hack/bin/ptz -a go_preset -f $SONOFF_HACK_PREFIX/etc/ptz_presets.conf -n $(get_config PTZ_PRESET_BOOT)) &
+    fi
 fi
 
 if [[ $(get_config DISABLE_CLOUD) == "yes" ]] ; then
@@ -285,15 +288,17 @@ if [[ $(get_config ONVIF) == "yes" ]] ; then
         echo "" >> $ONVIF_SRVD_CONF
     fi
 
-    echo "#PTZ" >> $ONVIF_SRVD_CONF
-    echo "ptz=1" >> $ONVIF_SRVD_CONF
-    echo "move_left=/mnt/mmc/sonoff-hack/bin/ptz -a left" >> $ONVIF_SRVD_CONF
-    echo "move_right=/mnt/mmc/sonoff-hack/bin/ptz -a right" >> $ONVIF_SRVD_CONF
-    echo "move_up=/mnt/mmc/sonoff-hack/bin/ptz -a up" >> $ONVIF_SRVD_CONF
-    echo "move_down=/mnt/mmc/sonoff-hack/bin/ptz -a down" >> $ONVIF_SRVD_CONF
-    echo "move_stop=/mnt/mmc/sonoff-hack/bin/ptz -a stop" >> $ONVIF_SRVD_CONF
-    echo "move_preset=/mnt/mmc/sonoff-hack/bin/ptz -f /mnt/mmc/sonoff-hack/etc/ptz_presets.conf -a go_preset -n %t" >> $ONVIF_SRVD_CONF
-    echo "set_preset=/mnt/mmc/sonoff-hack/bin/ptz -f /mnt/mmc/sonoff-hack/etc/ptz_presets.conf -a set_preset -e %n -n %t" >> $ONVIF_SRVD_CONF
+    if [[ $PTZ_PRESENT -eq 1 ]]; then
+        echo "#PTZ" >> $ONVIF_SRVD_CONF
+        echo "ptz=1" >> $ONVIF_SRVD_CONF
+        echo "move_left=/mnt/mmc/sonoff-hack/bin/ptz -a left" >> $ONVIF_SRVD_CONF
+        echo "move_right=/mnt/mmc/sonoff-hack/bin/ptz -a right" >> $ONVIF_SRVD_CONF
+        echo "move_up=/mnt/mmc/sonoff-hack/bin/ptz -a up" >> $ONVIF_SRVD_CONF
+        echo "move_down=/mnt/mmc/sonoff-hack/bin/ptz -a down" >> $ONVIF_SRVD_CONF
+        echo "move_stop=/mnt/mmc/sonoff-hack/bin/ptz -a stop" >> $ONVIF_SRVD_CONF
+        echo "move_preset=/mnt/mmc/sonoff-hack/bin/ptz -f /mnt/mmc/sonoff-hack/etc/ptz_presets.conf -a go_preset -n %t" >> $ONVIF_SRVD_CONF
+        echo "set_preset=/mnt/mmc/sonoff-hack/bin/ptz -f /mnt/mmc/sonoff-hack/etc/ptz_presets.conf -a set_preset -e %n -n %t" >> $ONVIF_SRVD_CONF
+    fi
 
     onvif_srvd --conf_file $ONVIF_SRVD_CONF
 

--- a/src/www/httpd/cgi-bin/status.json
+++ b/src/www/httpd/cgi-bin/status.json
@@ -10,7 +10,13 @@ HOSTNAME=$(hostname)
 FW_VERSION=$(cat /mnt/mmc/sonoff-hack/version)
 HOME_VERSION=$(cat /mnt/mtd/ipc/cfg/version)
 MODEL=$(cat $MODEL_CFG_FILE | grep model | cut -d'=' -f2 | cut -d'"' -f2)
-PTZ="yes"
+PTZ=$(cat /proc/modules | grep -o ptz_drv)
+if [ -n "$PTZ" ]; then
+    PTZ="yes"
+else
+    PTZ="no"
+fi
+
 SERIAL_NUMBER=$(cat /mnt/mtd/ipc/cfg/colink.conf | grep devid | cut -d "=" -f2 | cut -d'"' -f2)
 DEVICE_ID=$(cat /mnt/mtd/ipc/cfg/colink.conf | grep devid | cut -d "=" -f2 | cut -d'"' -f2)
 LOCAL_TIME=$(date)


### PR DESCRIPTION
I have a new Sonoff Slim Cam model ```S-CAM``` that is running firmware ```V5520.2053.0402build20220712``` this seems to be the same or similar build as the one for the ```GK-200MP2-B```. I have been testing this with the existing 0.1.3 release for ```GK-200MP2-B``` and everything seems to be working as expected. The model is correctly detected as ```S-CAM```, /etc is readonly and the audio files are in the same locations as the GK-200MP2-B build.

This camera does not support PTZ and as a result the ```ptz_drv``` kernel module is not loaded on boot by default. However it does exist in the firmware image and ends up being loaded by the sonoff-hack scripts. 

This pull request avoids loading the ptz_drv module (saving a little bit of precious RAM) and ensures that PTZ is not enabled/setup in ONVIF and the webui.

I have not tested with a PTZ camera as I dont have any hardware, however so long as the  ```ptz_drv``` is always actually loaded on boot then it wont cause any change in behaviour on these cameras.