### PR TITLE
build script cleanups

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -37,15 +37,10 @@ echo ""
 BASE_DIR=$(get_script_dir)/../
 BASE_DIR=$(normalize_path $BASE_DIR)
 
-SYSROOT_DIR=$BASE_DIR/sysroot
 STATIC_DIR=$BASE_DIR/static
 BUILD_DIR=$BASE_DIR/build
 OUT_DIR=$BASE_DIR/out
 
-echo "Cleaning sysroot ..."
-for CAMERA_NAME in "${!CAMERAS[@]}"; do
-    rm -rf $SYSROOT_DIR/$CAMERA_NAME
-done
 echo "Cleaning build dir ..."
 rm -rf $BUILD_DIR
 echo "Cleaning out dir ..."

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -77,3 +77,49 @@ get_camera_id()
     check_camera_name $CAMERA_NAME
     echo ${CAMERAS[$CAMERA_NAME]}
 }
+
+compile_module()
+{
+    (
+    local MOD_DIR=$1
+    local MOD_NAME=$(basename "$MOD_DIR")
+
+    local MOD_INIT="init.$MOD_NAME"
+    local MOD_COMPILE="compile.$MOD_NAME"
+    local MOD_INSTALL="install.$MOD_NAME"
+
+    printf "MOD_DIR:        %s\n" "$MOD_DIR"
+    printf "MOD_NAME:       %s\n" "$MOD_NAME"
+    printf "MOD_INIT:       %s\n" "$MOD_INIT"
+    printf "MOD_COMPILE:    %s\n" "$MOD_COMPILE"
+    printf "MOD_INSTALL:    %s\n" "$MOD_INSTALL"
+
+    cd "$MOD_DIR"
+
+    if [ ! -f $MOD_INIT ]; then
+        echo "$MOD_INIT not found.. exiting."
+        exit 1
+    fi
+    if [ ! -f $MOD_COMPILE ]; then
+        echo "$MOD_COMPILE not found.. exiting."
+        exit 1
+    fi
+    if [ ! -f $MOD_INSTALL ]; then
+        echo "$MOD_INSTALL not found.. exiting."
+        exit 1
+    fi
+
+    echo ""
+
+    printf "Initializing $MOD_NAME...\n\n"
+    ./$MOD_INIT || exit 1
+
+    printf "Compiling $MOD_NAME...\n\n"
+    ./$MOD_COMPILE || exit 1
+
+    printf "Installing '$MOD_INSTALL' in the firmware...\n\n"
+    ./$MOD_INSTALL || exit 1
+
+    printf "\n\nDone!\n\n"
+    )
+}

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -23,77 +23,8 @@ get_script_dir()
     echo "$(cd `dirname $0` && pwd)"
 }
 
-compile_module()
-{
-    (
-    local MOD_DIR=$1
-    local MOD_NAME=$(basename "$MOD_DIR")
+SCRIPT_DIR=$(get_script_dir)
 
-    local MOD_INIT="init.$MOD_NAME"
-    local MOD_COMPILE="compile.$MOD_NAME"
-    local MOD_INSTALL="install.$MOD_NAME"
-
-    printf "MOD_DIR:        %s\n" "$MOD_DIR"
-    printf "MOD_NAME:       %s\n" "$MOD_NAME"
-    printf "MOD_INIT:       %s\n" "$MOD_INIT"
-    printf "MOD_COMPILE:    %s\n" "$MOD_COMPILE"
-    printf "MOD_INSTALL:    %s\n" "$MOD_INSTALL"
-
-    cd "$MOD_DIR"
-
-    if [ ! -f $MOD_INIT ]; then
-        echo "$MOD_INIT not found.. exiting."
-        exit 1
-    fi
-    if [ ! -f $MOD_COMPILE ]; then
-        echo "$MOD_COMPILE not found.. exiting."
-        exit 1
-    fi
-    if [ ! -f $MOD_INSTALL ]; then
-        echo "$MOD_INSTALL not found.. exiting."
-        exit 1
-    fi
-
-    echo ""
-
-    printf "Initializing $MOD_NAME...\n\n"
-    ./$MOD_INIT || exit 1
-
-    printf "Compiling $MOD_NAME...\n\n"
-    ./$MOD_COMPILE || exit 1
-
-    printf "Installing '$MOD_INSTALL' in the firmware...\n\n"
-    ./$MOD_INSTALL || exit 1
-
-    printf "\n\nDone!\n\n"
-    )
-}
-
-###############################################################################
-
-source "$(get_script_dir)/common.sh"
-
-echo ""
-echo "------------------------------------------------------------------------"
-echo " SONOFF-HACK - SRC COMPILER"
-echo "------------------------------------------------------------------------"
-echo ""
-
-rm -rf "$(get_script_dir)/../build/"
-
-mkdir -p "$(get_script_dir)/../build/sonoff-hack"
-
-SRC_DIR=$(get_script_dir)/../src
-
-for SUB_DIR in $SRC_DIR/* ; do
-    if [ -d ${SUB_DIR} ]; then # Will not run if no directories are available
-        compile_module $(normalize_path "$SUB_DIR") || exit 1
-    fi
-done
-
-BIN_DIR=$(get_script_dir)/../bin
-BUILD_DIR=$(get_script_dir)/../build
-
-if [ -d "$BIN_DIR" ]; then
-    cp -R $BIN_DIR/* $BUILD_DIR/
-fi
+[ -z "$1" ] && rm -rf "${SCRIPT_DIR}/../build"
+source ${SCRIPT_DIR}/compile_ci_pre.sh
+source ${SCRIPT_DIR}/compile_ci_post.sh

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -79,10 +79,6 @@ echo " SONOFF-HACK - SRC COMPILER"
 echo "------------------------------------------------------------------------"
 echo ""
 
-# this is needed because with sudo the PATH apparently doesn't contain it. Idk why
-# Hisilicon Linux, Cross-Toolchain PATH
-export PATH="/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin:$PATH"
-
 rm -rf "$(get_script_dir)/../build/"
 
 mkdir -p "$(get_script_dir)/../build/sonoff-hack"

--- a/scripts/compile_ci_pre.sh
+++ b/scripts/compile_ci_pre.sh
@@ -33,6 +33,10 @@ echo " SONOFF-HACK - SRC COMPILER"
 echo "------------------------------------------------------------------------"
 echo ""
 
+if [ -d /home/user/x-tools/arm-sonoff-linux-uclibcgnueabi ]; then
+    export PATH="/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin:$PATH"
+fi
+
 mkdir -p "${SCRIPT_DIR}/../build/sonoff-hack"
 SRC_DIR=${SCRIPT_DIR}/../src
 

--- a/scripts/compile_ci_pre.sh
+++ b/scripts/compile_ci_pre.sh
@@ -23,55 +23,7 @@ get_script_dir()
     echo "$(cd `dirname $0` && pwd)"
 }
 
-compile_module()
-{
-    (
-    local MOD_DIR=$1
-    local MOD_NAME=$(basename "$MOD_DIR")
-
-    local MOD_INIT="init.$MOD_NAME"
-    local MOD_COMPILE="compile.$MOD_NAME"
-    local MOD_INSTALL="install.$MOD_NAME"
-
-    printf "MOD_DIR:        %s\n" "$MOD_DIR"
-    printf "MOD_NAME:       %s\n" "$MOD_NAME"
-    printf "MOD_INIT:       %s\n" "$MOD_INIT"
-    printf "MOD_COMPILE:    %s\n" "$MOD_COMPILE"
-    printf "MOD_INSTALL:    %s\n" "$MOD_INSTALL"
-
-    cd "$MOD_DIR"
-
-    if [ ! -f $MOD_INIT ]; then
-        echo "$MOD_INIT not found.. exiting."
-        exit 1
-    fi
-    if [ ! -f $MOD_COMPILE ]; then
-        echo "$MOD_COMPILE not found.. exiting."
-        exit 1
-    fi
-    if [ ! -f $MOD_INSTALL ]; then
-        echo "$MOD_INSTALL not found.. exiting."
-        exit 1
-    fi
-
-    echo ""
-
-    printf "Initializing $MOD_NAME...\n\n"
-    ./$MOD_INIT || exit 1
-
-    printf "Compiling $MOD_NAME...\n\n"
-    ./$MOD_COMPILE || exit 1
-
-    printf "Installing '$MOD_INSTALL' in the firmware...\n\n"
-    ./$MOD_INSTALL || exit 1
-
-    printf "\n\nDone!\n\n"
-    )
-}
-
-###############################################################################
-
-export SCRIPT_DIR=$(get_script_dir)
+SCRIPT_DIR=$(get_script_dir)
 
 source "${SCRIPT_DIR}/common.sh"
 

--- a/scripts/pack_fw.all.sh
+++ b/scripts/pack_fw.all.sh
@@ -20,14 +20,14 @@
 
 get_script_dir()
 {
-    echo "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    echo "$(cd `dirname $0` && pwd)"
 }
 
 ###############################################################################
 
-source "$(get_script_dir)/common.sh"
-
 SCRIPT_DIR=$(get_script_dir)
+
+source "${SCRIPT_DIR}/common.sh"
 
 for CAMERA_NAME in "${!CAMERAS[@]}"; do 
     $SCRIPT_DIR/pack_fw.sh $CAMERA_NAME


### PR DESCRIPTION
A couple more cleanups to build scripts now that sudo is no longer required to pack firmware. 

Also deduplicate code between the compile scripts. I left the compile_ci_post.sh in there even though it doesnt appear to be used, could be useful for anyone wanting to add custom files onto sdcard as part of build.