### PR TITLE
Clean up build flags for container builds

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -32,6 +32,11 @@ CAMERAS["GK-200MP2-B"]="GK-200MP2-B"
 # Common functions
 ###############################################################################
 
+if [ -d /home/user/x-tools/arm-sonoff-linux-uclibcgnueabi ]; then
+    export PATH="/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin:$PATH"
+fi
+export CROSSLINK_BASE=$(dirname $(dirname $(which arm-sonoff-linux-uclibcgnueabi-gcc)))
+
 require_root()
 {
     if [ "$(whoami)" != "root" ]; then

--- a/scripts/compile_ci_pre.sh
+++ b/scripts/compile_ci_pre.sh
@@ -33,10 +33,6 @@ echo " SONOFF-HACK - SRC COMPILER"
 echo "------------------------------------------------------------------------"
 echo ""
 
-if [ -d /home/user/x-tools/arm-sonoff-linux-uclibcgnueabi ]; then
-    export PATH="/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin:$PATH"
-fi
-
 mkdir -p "${SCRIPT_DIR}/../build/sonoff-hack"
 SRC_DIR=${SCRIPT_DIR}/../src
 

--- a/scripts/pack_fw.sh
+++ b/scripts/pack_fw.sh
@@ -85,11 +85,7 @@ STATIC_DIR=$BASE_DIR/static
 BUILD_DIR=$BASE_DIR/build
 OUT_DIR=$BASE_DIR/out/$CAMERA_NAME
 VER=$(cat VERSION)
-if [ ! -z $(which arm-sonoff-linux-uclibcgnueabi-gcc) ]; then
-    CROSSLINK_SYSROOT=$(dirname $(dirname $(which arm-sonoff-linux-uclibcgnueabi-gcc)))/arm-sonoff-linux-uclibcgnueabi/sysroot
-else
-    CROSSLINK_SYSROOT=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot
-fi
+CROSSLINK_SYSROOT=${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot
 
 echo ""
 echo "------------------------------------------------------------------------"

--- a/src/dropbear/init.dropbear
+++ b/src/dropbear/init.dropbear
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CROSSLINK_BASE=${CROSSLINK_BASE:=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi}
+
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 cd $SCRIPT_DIR
 
@@ -12,7 +14,7 @@ autoconf; autoheader || exit 1
 
 ./configure CC=arm-sonoff-linux-uclibcgnueabi-gcc \
     --prefix=$SCRIPT_DIR/_install \
-    CFLAGS="-Os -I/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
+    CFLAGS="-Os -I${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
     AR=arm-sonoff-linux-uclibcgnueabi-ar \
     RANLIB=arm-sonoff-linux-uclibcgnueabi-ranlib \
     --host=arm \

--- a/src/ftpd/init.ftpd
+++ b/src/ftpd/init.ftpd
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CROSSLINK_BASE=${CROSSLINK_BASE:=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi}
+
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 cd $SCRIPT_DIR
 
@@ -12,7 +14,7 @@ git reset --hard || exit 1
 
 ./configure CC=arm-sonoff-linux-uclibcgnueabi-gcc \
     --prefix=$SCRIPT_DIR/_install \
-    CFLAGS="-Os -I/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
+    CFLAGS="-Os -I${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
     AR=arm-sonoff-linux-uclibcgnueabi-ar \
     RANLIB=arm-sonoff-linux-uclibcgnueabi-ranlib \
     --host=arm \

--- a/src/mosquitto/compile.mosquitto
+++ b/src/mosquitto/compile.mosquitto
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CROSSLINK_BASE=${CROSSLINK_BASE:=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi}
+
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 cd $SCRIPT_DIR
 
@@ -12,7 +14,7 @@ make -j$(nproc) \
     CROSS_COMPILE=arm-sonoff-linux-uclibcgnueabi- \
     CC=gcc \
     ARCH=arm \
-    CFLAGS="-Os -I/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/arm-sonoff-linux-uclibcgnueabi/sysroot/lib -DIPV6_V6ONLY=26" \
+    CFLAGS="-Os -I${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/lib -DIPV6_V6ONLY=26" \
     WITH_SRV=no \
     WITH_UUID=no \
     WITH_WEBSOCKETS=no \

--- a/src/snapshot/compile.snapshot
+++ b/src/snapshot/compile.snapshot
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-export CROSSPATH=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin
+CROSSLINK_BASE=${CROSSLINK_BASE:=/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi}
+export CROSSPATH=${CROSSLINK_BASE}/bin
 export PATH=${PATH}:${CROSSPATH}
 
 export TARGET=arm-sonoff-linux-uclibcgnueabi


### PR DESCRIPTION
Some build flags are still hard coded to use '/home/user/x-tools' paths. These wont work in container builds obviously. This will set these to the actual toolchain location. Will fallback to original behaviour if a submodule script is run directly rather than via compile.sh.