### PR TITLE
Cleanup configure arguments to be consistent across modules

### DIFF
--- a/src/dropbear/init.dropbear
+++ b/src/dropbear/init.dropbear
@@ -12,12 +12,10 @@ git reset --hard
 
 autoconf; autoheader || exit 1
 
-./configure CC=arm-sonoff-linux-uclibcgnueabi-gcc \
+./configure \
     --prefix=$SCRIPT_DIR/_install \
     CFLAGS="-Os -I${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
-    AR=arm-sonoff-linux-uclibcgnueabi-ar \
-    RANLIB=arm-sonoff-linux-uclibcgnueabi-ranlib \
-    --host=arm \
+    --host=arm-sonoff-linux-uclibcgnueabi \
     --disable-zlib \
     || exit 1
 

--- a/src/ftpd/init.ftpd
+++ b/src/ftpd/init.ftpd
@@ -12,11 +12,9 @@ git reset --hard || exit 1
 
 ./autogen.sh || exit 1
 
-./configure CC=arm-sonoff-linux-uclibcgnueabi-gcc \
+./configure \
     --prefix=$SCRIPT_DIR/_install \
     CFLAGS="-Os -I${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/usr/include -L${CROSSLINK_BASE}/arm-sonoff-linux-uclibcgnueabi/sysroot/lib" \
-    AR=arm-sonoff-linux-uclibcgnueabi-ar \
-    RANLIB=arm-sonoff-linux-uclibcgnueabi-ranlib \
-    --host=arm \
+    --host=arm-sonoff-linux-uclibcgnueabi \
     --with-minimal \
     || exit 1

--- a/src/libsqlite/compile.libsqlite
+++ b/src/libsqlite/compile.libsqlite
@@ -2,12 +2,6 @@
 
 export PATH=${PATH}:/home/user/x-tools/arm-sonoff-linux-uclibcgnueabi/bin
 
-export TARGET=arm-sonoff-linux-uclibcgnueabi
-export CROSS=arm-sonoff-linux-uclibcgnueabi
-export BUILD=x86_64-pc-linux-gnu
-
-export CROSSPREFIX=${CROSS}-
-
 SQLITE_VER="3080701"
 ARCHIVE=sqlite-autoconf-$SQLITE_VER
 
@@ -18,11 +12,7 @@ cd $ARCHIVE || exit 1
 
 make clean
 make || exit 1
-mkdir -p $SCRIPT_DIR/_install/bin
-cp .libs/sqlite3 $SCRIPT_DIR/_install/bin/
-mkdir -p $SCRIPT_DIR/_install/lib
-cp .libs/libsqlite3.so.0.8.6 $SCRIPT_DIR/_install/lib/
-ln -s libsqlite3.so.0.8.6 $SCRIPT_DIR/_install/lib/libsqlite3.so.0
-ln -s libsqlite3.so.0.8.6 $SCRIPT_DIR/_install/lib/libsqlite3.so
+
+make install-exec
 
 arm-sonoff-linux-uclibcgnueabi-strip ../_install/bin/*

--- a/src/libsqlite/init.libsqlite
+++ b/src/libsqlite/init.libsqlite
@@ -14,5 +14,7 @@ fi
 tar zxvf $ARCHIVE.tar.gz
 cd $ARCHIVE || exit 1
 
-export CFLAGS="-Os"
-./configure --host=arm-sonoff-linux-uclibcgnueabi
+./configure \
+    --prefix=$SCRIPT_DIR/_install \
+    CFLAGS="-Os" \
+    --host=arm-sonoff-linux-uclibcgnueabi

--- a/src/onvif_srvd/onvif_srvd/Makefile
+++ b/src/onvif_srvd/onvif_srvd/Makefile
@@ -306,8 +306,8 @@ define build_openssl
     # build
     if [ ! -f openssl/libcrypto.so.1.0.0 ] || [ ! -f openssl/libssl.so.1.0.0 ]; then \
         cd openssl; \
-        CC=arm-sonoff-linux-uclibcgnueabi-gcc ./Configure linux-sonoff && \
-        CC=arm-sonoff-linux-uclibcgnueabi-gcc make; \
+        ./Configure linux-sonoff --cross-compile-prefix=arm-sonoff-linux-uclibcgnueabi- && \
+        make; \
         cd ..;\
     fi
 endef

--- a/src/sftp-server/init.sftp-server
+++ b/src/sftp-server/init.sftp-server
@@ -10,9 +10,9 @@ git reset --hard
 
 autoreconf || exit 1
 
-./configure CC=arm-sonoff-linux-uclibcgnueabi-gcc \
+./configure \
     --prefix=$SCRIPT_DIR/_install \
-    --host=arm \
+    --host=arm-sonoff-linux-uclibcgnueabi \
     --without-openssl \
     --without-zlib \
     || exit 1


### PR DESCRIPTION
I noticed a couple of modules were picking up system versions of ar/ranlib rather the the toolchain versions. Fix that and a quick cleanup of configure arguments across modules. This should be good for any non-ancient autoconf i.e > 2.13.