### PR TITLE
Bump GitHub actions/checkout to use node16 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Prepare Env
         run: | 
             sudo apt update


### PR DESCRIPTION
Fixes deprecation warning in the GitHub Workflow due to upcoming node 12 removal.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/