### PR TITLE
Make sure /var/log exists before mounting

### DIFF
--- a/sdhack/boot.sh
+++ b/sdhack/boot.sh
@@ -3,6 +3,7 @@
 echo "############## Starting Hack ##############"
 
 # Fix log path
+mkdir -p /var/log
 mount --bind /var/sdcard/log /var/log
 
 # Remove audio messages during boot


### PR DESCRIPTION
I must have lost this when rebasing the PR.
Although I also had the Sonoff debug logging enabled via set_log_level which may have created this folder.