### PR TITLE
Revert changes to Dropbear config setting wrong paths

### DIFF
--- a/src/dropbear/localoptions.h
+++ b/src/dropbear/localoptions.h
@@ -1,16 +1,17 @@
 #ifndef DROPBEAR_LOCALOPTIONS_H
 #define DROPBEAR_LOCALOPTIONS_H
 
-#define DSS_PRIV_FILENAME "/tmp/sd/yi-hack/etc/dropbear/dropbear_dss_host_key"
-#define RSA_PRIV_FILENAME "/tmp/sd/yi-hack/etc/dropbear/dropbear_rsa_host_key"
-#define ECDSA_PRIV_FILENAME "/tmp/sd/yi-hack/etc/dropbear/dropbear_ecdsa_host_key"
-#define ED25519_PRIV_FILENAME "/tmp/sd/yi-hack/etc/dropbear/dropbear_ed25519_host_key"
+#define DSS_PRIV_FILENAME "/etc/dropbear/dropbear_dss_host_key"
+#define RSA_PRIV_FILENAME "/etc/dropbear/dropbear_rsa_host_key"
+#define ECDSA_PRIV_FILENAME "/etc/dropbear/dropbear_ecdsa_host_key"
+#define ED25519_PRIV_FILENAME "/etc/dropbear/dropbear_ed25519_host_key"
 
-#define DROPBEAR_PATH_SSH_PROGRAM "/tmp/sd/yi-hack/bin/dbclient"
+#define DROPBEAR_PATH_SSH_PROGRAM "/mnt/mmc/sonoff-hack/bin/dbclient"
 
-#define DEFAULT_PATH "/usr/bin:/usr/sbin:/bin:/sbin:/gm/bin:/gm/tools:/tmp/sd/yi-hack/bin:/tmp/sd/yi-hack/sbin:/tmp/sd/yi-hack/usr/bin:/tmp/sd/yi-hack/usr/sbin"
-#define DEFAULT_ROOT_PATH "/usr/bin:/usr/sbin:/bin:/sbin:/gm/bin:/gm/tools:/tmp/sd/yi-hack/bin:/tmp/sd/yi-hack/sbin:/tmp/sd/yi-hack/usr/bin:/tmp/sd/yi-hack/usr/sbin"
+#define DEFAULT_PATH "/usr/bin:/bin:/gm/bin:/gm/tools:/mnt/mmc/sonoff-hack/bin:/mnt/mmc/sonoff-hack/usr/bin"
+#define DEFAULT_ROOT_PATH "/usr/bin:/usr/sbin:/bin:/sbin:/gm/bin:/gm/tools:/mnt/mmc/sonoff-hack/bin:/mnt/mmc/sonoff-hack/sbin:/mnt/mmc/sonoff-hack/usr/bin:/mnt/mmc/sonoff-hack/usr/sbin"
 
-#define SFTPSERVER_PATH "/tmp/sd/yi-hack/usr/libexec/sftp-server"
+#define SFTPSERVER_PATH "/mnt/mmc/sonoff-hack/usr/libexec/sftp-server"
+
 
 #endif /* DROPBEAR_LOCALOPTIONS_H */


### PR DESCRIPTION
Dropbear settings got overwritten in commit 9bd2e3d5a47. Revert these changes for sonoff-hack settings.

Per Issue #166

I dont currently have an active cam to test this on though