### PR TITLE
Add control of pan and tilt from MQTT topics

### DIFF
--- a/src/mqtt/mqtt-sonoff/include/mqtt-sonoff.h
+++ b/src/mqtt/mqtt-sonoff/include/mqtt-sonoff.h
@@ -41,6 +41,8 @@
 #define MQTT_SONOFF_SNAPSHOT     "/mnt/mmc/sonoff-hack/bin/snapshot"
 #define CONF2MQTT_SCRIPT         "/mnt/mmc/sonoff-hack/script/conf2mqtt.sh"
 #define IPC_CMD                  "/mnt/mmc/sonoff-hack/bin/ipc_cmd"
+#define PTZ_CMD                  "/mnt/mmc/sonoff-hack/bin/ptz"
+
 
 #define MOTION_ALARM_FILE        "/tmp/onvif_notify_server/motion_alarm"
 

--- a/src/mqtt/mqtt-sonoff/src/mqtt-sonoff.c
+++ b/src/mqtt/mqtt-sonoff/src/mqtt-sonoff.c
@@ -563,6 +563,43 @@ static void send_ha_discovery() {
         mqtt_send_message(&msg, retain);
         free(msg.msg);
 
+        // Send pan config
+        msg.msg=print_switch_json("pan_left", "mdi:video");
+        cJSON_Minify(msg.msg);
+        msg.len=strlen(msg.msg);
+
+        sprintf(topic, "%s/switch/%s_pan_left/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
+        mqtt_send_message(&msg, retain);
+        free(msg.msg);
+
+        // Send pan_right config
+        msg.msg=print_switch_json("pan_right", "mdi:video");
+        cJSON_Minify(msg.msg);
+        msg.len=strlen(msg.msg);
+
+        sprintf(topic, "%s/switch/%s_pan_right/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
+        mqtt_send_message(&msg, retain);
+        free(msg.msg);
+
+        // Send pan_up config
+        msg.msg=print_switch_json("pan_up", "mdi:video");
+        cJSON_Minify(msg.msg);
+        msg.len=strlen(msg.msg);
+
+        sprintf(topic, "%s/switch/%s_pan_up/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
+        mqtt_send_message(&msg, retain);
+        free(msg.msg);
+
+        // Send pan_down config
+        msg.msg=print_switch_json("pan_down", "mdi:video");
+        cJSON_Minify(msg.msg);
+        msg.len=strlen(msg.msg);
+
+        sprintf(topic, "%s/switch/%s_pan_down/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
+        mqtt_send_message(&msg, retain);
+        free(msg.msg);
+
+
         // Send motion_detection config
         msg.msg=print_switch_json("motion_detection", "mdi:motion-sensor");
         cJSON_Minify(msg.msg);

--- a/src/mqtt/mqtt-sonoff/src/mqtt.c
+++ b/src/mqtt/mqtt-sonoff/src/mqtt.c
@@ -428,6 +428,38 @@ static void message_callback(struct mosquitto *mosq, void *obj, const struct mos
             sprintf(cmd_line, "%s -t off", IPC_CMD);
             system(cmd_line);
         }
+    } else if (strcasecmp("pan_left", param) == 0) {
+        if ((strcasecmp("on", (char *) message->payload) == 0) || (strcasecmp("yes", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop; %s -a left", PTZ_CMD, PTZ_CMD);
+            system(cmd_line);
+        } else if ((strcasecmp("off", (char *) message->payload) == 0) || (strcasecmp("no", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop", PTZ_CMD);
+            system(cmd_line);
+        }
+    } else if (strcasecmp("pan_right", param) == 0) {
+        if ((strcasecmp("on", (char *) message->payload) == 0) || (strcasecmp("yes", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop; %s -a right", PTZ_CMD, PTZ_CMD);
+            system(cmd_line);
+        } else if ((strcasecmp("off", (char *) message->payload) == 0) || (strcasecmp("no", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop", PTZ_CMD);
+            system(cmd_line);
+        }
+    } else if (strcasecmp("pan_up", param) == 0) {
+        if ((strcasecmp("on", (char *) message->payload) == 0) || (strcasecmp("yes", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop; %s -a up", PTZ_CMD, PTZ_CMD);
+            system(cmd_line);
+        } else if ((strcasecmp("off", (char *) message->payload) == 0) || (strcasecmp("no", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop", PTZ_CMD);
+            system(cmd_line);
+        }
+    } else if (strcasecmp("pan_down", param) == 0) {
+        if ((strcasecmp("on", (char *) message->payload) == 0) || (strcasecmp("yes", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop; %s -a down", PTZ_CMD, PTZ_CMD);
+            system(cmd_line);
+        } else if ((strcasecmp("off", (char *) message->payload) == 0) || (strcasecmp("no", (char *) message->payload) == 0)) {
+            sprintf(cmd_line, "%s -a stop", PTZ_CMD);
+            system(cmd_line);
+        }
     } else if (strcasecmp("motion_detection", param) == 0) {
         if ((strcasecmp("on", (char *) message->payload) == 0) || (strcasecmp("yes", (char *) message->payload) == 0)) {
             sprintf(cmd_line, "%s -m on", IPC_CMD);


### PR DESCRIPTION
As the title said, this adds whatever required for controlling pan tilt from MQTT (avoiding mixed HTTP/MQTT in Home Assistant).

In Home Assistant, I've added a script like this:
```yaml
alias: Pan Camera
sequence:
  - action: switch.turn_on
    data: {}
    target:
      entity_id: switch.pt_{{direction}}
  - delay:
      hours: 0
      minutes: 0
      seconds: 0
      milliseconds: 500
  - action: switch.turn_off
    data: {}
    target:
      entity_id: switch.pt_{{direction}}
description: Pan camera
icon: mdi:arrow-decision-outline
```

And added Webrtc config like this:
```yaml
type: custom:webrtc-camera
url: rtsp://hack:hack@yourip:554/av_stream/ch0
ptz:
  opacity: 0.4
  service: script.pan_camera
  data_left:
    direction: pan_left
  data_right:
    direction: pan_right
  data_up:
    direction: pan_up
  data_down:
    direction: pan_down
```
