### PR TITLE
Init WiFi configuration with init file on SD Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,17 @@ USE AT YOUR OWN RISK.
 
 4. Decompress the file (tgz format) on root path of microSD card.
 
-5. Remove power to the camera, insert the microSD card, turn the power back ON.
+5. (Model: S-Cam) If WiFi needed but configured yet: rename microSD/wifi_init.example.txt to microSD/wifi_init.txt and fill in your ESSID and WiFi Password
 
-6. Wait a minute.
+6. Remove power to the camera, insert the microSD card, turn the power back ON.
 
-7. Go in the browser and access the web interface of the camera as a website (http://IP-CAM). Find the IP address on your router's portal (see connected devices).
+7. Wait a minute.
 
-8. Don't remove the microSD card (yes this hack requires a dedicated microSD card).
+8. Go in the browser and access the web interface of the camera as a website (http://IP-CAM). Find the IP address on your router's portal (see connected devices).
 
-9. Done.
+9. Don't remove the microSD card (yes this hack requires a dedicated microSD card).
+
+10. Done.
 
 ## URLs, Ports and Default RTSP Password
 For both streams if you've set a custom username and password on the config screen don't forget to replace "hack" at the beginning of the URLs! First one is username, second is password. If you want to view the stream in, as example, VLC and haven't set a password you need to enter "hack" for both user and pass.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ USE AT YOUR OWN RISK.
 
 4. Decompress the file (tgz format) on root path of microSD card.
 
-5. (Model: S-Cam) If WiFi needed but configured yet: rename microSD/wifi_init.example.txt to microSD/wifi_init.txt and fill in your ESSID and WiFi Password
+5. (Model: S-Cam) If WiFi needed, but not configured yet: rename microSD/wifi_init.example.txt to microSD/wifi_init.txt and fill in your ESSID and WiFi password
 
 6. Remove power to the camera, insert the microSD card, turn the power back ON.
 

--- a/sdhack/boot.sh
+++ b/sdhack/boot.sh
@@ -17,9 +17,49 @@ mount --bind /tmp/EmptyAudio.wav $WAV_FILE_DIR/Internet_connected_Welcome_to_use
 mount --bind /tmp/EmptyAudio.wav $WAV_FILE_DIR/WiFi_connect_success.wav
 mount --bind /tmp/EmptyAudio.wav $WAV_FILE_DIR/Please_use_mobile_phone_for_WiFi_configuration.wav
 
+# Initialize WiFi               
+WPA_FILE="/mnt/mtd/ipc/cfg/wpa_supplicant.conf"
+WPA_INIT_FILE="/var/sdcard/wifi_init.txt"
+cp $WPA_FILE /var/sdcard/
+if [ -f $WPA_INIT_FILE ]; then
+    echo "init wifi" >> /var/log/boot.log
+    # Load variables WIFI_ESSID and WIFI_KEY from ini file
+    . $WPA_INIT_FILE
+    
+    # Check for required variables WIFI_ESSID and WIFI_KEY
+    if [ -n "$WIFI_ESSID" ] || [ -n "$WIFI_KEY" ]; then
+        /var/sdcard/sonoff-hack/bin/sqlite3 /mnt/mtd/db/ipcsys.db \
+           "update t_sys_param set c_param_value='$WIFI_ESSID' where c_param_name='wf_ssid'; \
+            update t_sys_param set c_param_value='$WIFI_KEY' where c_param_name='wf_key';
+            update t_sys_param set c_param_value='1' where c_param_name='wf_status'; \
+            update t_sys_param set c_param_value='3' where c_param_name='wf_auth'; \
+            update t_sys_param set c_param_value='1' where c_param_name='wf_enc';"
+
+        cat << EOF > $WPA_FILE
+ctrl_interface=/var/run/wpa_supplicant
+update_config=1
+network={
+	ssid="$WIFI_ESSID"
+	scan_ssid=1
+	key_mgmt=WPA-EAP WPA-PSK IEEE8021X NONE
+	pairwise=TKIP CCMP
+	group=CCMP TKIP WEP104 WEP40
+	psk="$WIFI_KEY"
+}
+EOF
+        mv $WPA_INIT_FILE ${WPA_INIT_FILE}.done
+    else
+        mv $WPA_INIT_FILE ${WPA_INIT_FILE}.failed
+    fi
+fi
+
 # Add script for network management
 cp /mnt/mtd/ipc/app/script/dhcp.sh /tmp/dhcp.sh
-sed -i "s/udhcpc -a.*/\/mnt\/mmc\/network.sh \$1/g" /tmp/dhcp.sh
+sed -i "s~udhcpc -a.*~/mnt/mmc/network.sh \$1~g" /tmp/dhcp.sh
+
+# Make wifi work, even if not configured over eWeLink App
+# Check for DyVoiceRecog or wpa_supplicant file
+sed -i "s~\(DyVoiceRecog\.bin\)~\1\" ] || [ -f \"$WPA_FILE~g" /tmp/dhcp.sh
 mount --bind /tmp/dhcp.sh /mnt/mtd/ipc/app/script/dhcp.sh
 
 # Remove colink binary

--- a/sdhack/wifi_init.example.txt
+++ b/sdhack/wifi_init.example.txt
@@ -1,4 +1,4 @@
 # Enter your WPA2 ESSID and Key/Password
 # Rename file to wifi_init.txt
-WIFI_ESSID="Put your ESSI here"
+WIFI_ESSID="Put your ESSID here"
 WIFI_KEY="Put your password here"

--- a/sdhack/wifi_init.example.txt
+++ b/sdhack/wifi_init.example.txt
@@ -1,0 +1,4 @@
+# Enter your WPA2 ESSID and Key/Password
+# Rename file to wifi_init.txt
+WIFI_ESSID="Put your ESSI here"
+WIFI_KEY="Put your password here"


### PR DESCRIPTION
This is one piece to get closer to use sonoff cameras without the ewelink app.
In particular it's needed for s-cams without ethernet port.

Place a "wifi_init.txt" file on the sd-card and wifi will be configured. If successfull, it's being renamed to wifi_init.txt.done. If it fails it's renamed to wifi_init.txt.failed

Maybe there is another place to document this?
Maybe the configuration file should be deleted after configuration?