### PR TITLE
Consistent make files: use all processors on all make commands

### DIFF
--- a/src/ipc_cmd/compile.ipc_cmd
+++ b/src/ipc_cmd/compile.ipc_cmd
@@ -22,7 +22,7 @@ cd $SCRIPT_DIR
 cd ipc_cmd || exit 1
 
 make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 mkdir -p ../_install/bin || exit 1
 

--- a/src/libsqlite/compile.libsqlite
+++ b/src/libsqlite/compile.libsqlite
@@ -11,7 +11,7 @@ cd $SCRIPT_DIR
 cd $ARCHIVE || exit 1
 
 make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 make install-exec
 

--- a/src/onvif_simple_server/compile.onvif_simple_server
+++ b/src/onvif_simple_server/compile.onvif_simple_server
@@ -36,7 +36,7 @@ fi
 cd onvif_simple_server || exit 1
 
 #make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 mkdir -p ../_install/www/onvif || exit 1
 mkdir -p ../_install/bin || exit 1

--- a/src/ptz/compile.ptz
+++ b/src/ptz/compile.ptz
@@ -22,7 +22,7 @@ cd $SCRIPT_DIR
 cd ptz || exit 1
 
 make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 mkdir -p ../_install/bin || exit 1
 mkdir -p ../_install/lib || exit 1

--- a/src/ptz/ptz/Makefile
+++ b/src/ptz/ptz/Makefile
@@ -20,13 +20,13 @@ ptz_h: $(OBJECTS)
 	$(STRIP) $@
 
 libptz:
-	make -C minilib
+	$(MAKE) -C minilib
 
 .PHONY: clean
 
 clean:
 	rm -f ptz_p ptz_h
 	rm -f $(OBJECTS)
-	make -C minilib clean
+	$(MAKE) -C minilib clean
 
 distclean: clean

--- a/src/record/compile.record
+++ b/src/record/compile.record
@@ -22,7 +22,7 @@ cd $SCRIPT_DIR
 cd record || exit 1
 
 make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 mkdir -p ../_install/bin || exit 1
 

--- a/src/snapshot/compile.snapshot
+++ b/src/snapshot/compile.snapshot
@@ -23,7 +23,7 @@ cd $SCRIPT_DIR
 cd snapshot || exit 1
 
 make clean
-make || exit 1
+make -j $(nproc) || exit 1
 
 mkdir -p ../_install/bin || exit 1
 mkdir -p ../_install/etc/wm_res || exit 1

--- a/src/snapshot/snapshot/Makefile
+++ b/src/snapshot/snapshot/Makefile
@@ -11,7 +11,11 @@ INC_J = -I$(JPEGLIB_DIR)
 LIB_J = $(JPEGLIB_DIR)/.libs/libjpeg.a
 OPTS = -Os -ffunction-sections -fdata-sections
 
-all: snapshot libs imggrabber resize_jpg
+all:
+	$(MAKE) libs
+	$(MAKE) snapshot
+	$(MAKE) imggrabber
+	$(MAKE) resize_jpg
 
 %.o : %.c $(HEADERS)
 	$(CC) -c $< $(OPTS) $(INC_J) $(INC_FF) -fPIC -o $@
@@ -62,7 +66,7 @@ define build_ffmpeg
     if [ ! -f $(FFMPEG)/libavcodec/libavcodec.a ] || [ ! -f $(FFMPEG)/libavutil/libavutil.a ]; then \
          cd $(FFMPEG); \
         ./configure --enable-cross-compile --cross-prefix=$(CROSSPREFIX) --arch=armel --target-os=linux --prefix=$(CROSSPATH) --enable-small --disable-ffplay --disable-ffprobe --disable-doc  --disable-decoders --enable-decoder=h264 --disable-encoders --disable-demuxers --enable-demuxer=h264 --disable-muxers --disable-protocols --disable-parsers --enable-parser=h264 --disable-filters --disable-bsfs --disable-indevs --disable-outdevs --extra-cflags="-Os -ffunction-sections -fdata-sections" && \
-         make; \
+         $(MAKE); \
          cd ..;\
     fi
 endef
@@ -85,7 +89,7 @@ define build_jpeglib
     if [ ! -f $(JPEGLIB)/.libs/libjpeg.a ]; then \
         cd $(JPEGLIB); \
         ./configure --host=$(CROSS) --enable-shared=yes && \
-        make CFLAGS+="-Os -ffunction-sections -fdata-sections"; \
+        $(MAKE) CFLAGS+="-Os -ffunction-sections -fdata-sections"; \
         cd ..;\
     fi
 endef


### PR DESCRIPTION
I noticed some folders in sonoff-hack would just build slow. I saw that "-j" was not present for all make calls. So i added the option "-j" to all make calls.