### PR TITLE
Speedup serving configs as json

### DIFF
--- a/src/www/httpd/cgi-bin/get_configs.sh
+++ b/src/www/httpd/cgi-bin/get_configs.sh
@@ -37,7 +37,7 @@ fi
 
 printf "{\n"
 
-sed '/^#/d; /^$/d; s/\([^=]*\)=\(.*\)/"\1":"\2",/' "$CONF_FILE"
+sed '/^#/d; /^$/d; s/\\/\\\\/g; s/\"/\\"/g; s/\([^=]*\)=\(.*\)/"\1":"\2",/' "$CONF_FILE"
 
 if [ "$CONF_TYPE" == "system" ] ; then
     printf "\"%s\":\"%s\",\n"  "HOSTNAME" "$(cat $SONOFF_HACK_PREFIX/etc/hostname | sed -r 's/\\/\\\\/g;s/"/\\"/g;')"

--- a/src/www/httpd/cgi-bin/get_configs.sh
+++ b/src/www/httpd/cgi-bin/get_configs.sh
@@ -37,16 +37,7 @@ fi
 
 printf "{\n"
 
-while IFS= read -r LINE ; do
-    if [ ! -z "$LINE" ] ; then
-        if [ "$LINE" == "${LINE#\#}" ] ; then # skip comments
-#            printf "\"%s\",\n" $(echo "$LINE" | sed -r 's/\\/\\\\/g;s/"/\\"/g;s/=/":"/g;') # Format to json and replace = with ":"
-            echo -n "\""
-            echo -n "$LINE" | sed -r 's/\\/\\\\/g;s/\"/\\"/g;s/=/":"/g;s/\\\\n/\\n/g;'
-            echo "\","
-        fi
-    fi
-done < "$CONF_FILE"
+sed '/^#/d; /^$/d; s/\([^=]*\)=\(.*\)/"\1":"\2",/' "$CONF_FILE"
 
 if [ "$CONF_TYPE" == "system" ] ; then
     printf "\"%s\":\"%s\",\n"  "HOSTNAME" "$(cat $SONOFF_HACK_PREFIX/etc/hostname | sed -r 's/\\/\\\\/g;s/"/\\"/g;')"


### PR DESCRIPTION
On my camera the load times for the requests to get_config.sh?conf= changed as follows:
ptz page:
system: before 10s => after 3.6s
ptz_presets: before 3.8s => after 1.7s

mqtt page:
system: before 5.8s => after 1.2s
mqtt: before 4.2s => after 0.7s