### PR TITLE
Fixed typo in HA motion sensor discovery message

### DIFF
--- a/src/mqtt/mqtt-sonoff/src/mqtt-sonoff.c
+++ b/src/mqtt/mqtt-sonoff/src/mqtt-sonoff.c
@@ -572,7 +572,7 @@ static void send_ha_discovery() {
         cJSON_Minify(msg.msg);
         msg.len=strlen(msg.msg);
 
-        snprintf(topic, sizeof(topic), "%s/binary_sensor/%s_mot ion/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
+        snprintf(topic, sizeof(topic), "%s/binary_sensor/%s_motion/config", mqtt_sonoff_conf.ha_conf_prefix, mqtt_sonoff_conf.device_id);
         mqtt_send_message(&msg, retain);
         free(msg.msg);
 


### PR DESCRIPTION
I think it fixes the issue https://github.com/roleoroleo/sonoff-hack/issues/199 