### PR TITLE
feat: add speed control option for PTZ movement

### DIFF
--- a/src/ptz/ptz/minilib/libptz.c
+++ b/src/ptz/ptz/minilib/libptz.c
@@ -45,8 +45,8 @@ int hw_ptz_sendptz(int *ptz_arg) {
         printf("    errno = %s\n", strerror(errno));
         error = 1;
     }
-    if ((ptz_arg[2] > 1) && (ptz_arg[2] < 4)) {
-        value = 5 - ptz_arg[2];
+    if ((ptz_arg[2] > 0) && (ptz_arg[2] < 65535)) {
+        value = ptz_arg[2];
 	    if (!error && ioctl(fd_driver, 0x9, &value) < 0) {
 			printf("Error ioctl 0x9\n");
             printf("    errno = %s\n", strerror(errno));


### PR DESCRIPTION
this adds a raw speed control for ptz. In my testing the speed goes from 0 (unset, max speed) all the way up to whatever value (at some point it pretty much stops moving), so I added a max (min) speed of 65k.

the current PTZ speed is way too fast and it causes issues. With this we can configure a slower speed (especially for the ONVIF commands)