### PR TITLE
Fix preset.sh returning invalid http response

### DIFF
--- a/src/www/httpd/cgi-bin/preset.sh
+++ b/src/www/httpd/cgi-bin/preset.sh
@@ -46,7 +46,7 @@ if [ "$ACTION" != "go_preset" ] && [ "$ACTION" != "set_preset" ] && [ "$ACTION" 
 fi
 
 if [ "$ACTION" == "set_home" ]; then
-    NUM = 0
+    NUM=0
 fi
 
 if [ $NUM -eq -1 ]; then
@@ -81,7 +81,7 @@ if [ "$NAME" != "none" ]; then
     ARG_NAME="-e $NAME"
 fi
 
-$SONOFF_HACK_PREFIX/bin/ptz -f $SONOFF_HACK_PREFIX/etc/ptz_presets.conf $ARG_ACTION $ARG_NUM $ARG_NAME
+$SONOFF_HACK_PREFIX/bin/ptz -f $SONOFF_HACK_PREFIX/etc/ptz_presets.conf $ARG_ACTION $ARG_NUM $ARG_NAME >/dev/null 2>&1
 
 printf "Content-type: application/json\r\n\r\n"
 printf "{\n"


### PR DESCRIPTION
Since a recent update of the firmware on my camera, I had a lot of error logs in my home assistant instance :
```
Failed to parse headers (url=http://XXXX/cgi-bin/preset.sh?action=go_preset&num=0): [MissingHeaderBodySeparatorDefect()], unparsed data: 'PTZ_CMD_GOTO_POS pPtzInfo->nXPos=1750 ,pPtzInfo->nYPos=1365\nContent-type: application/json\r\n\r\n'
Failed to parse headers (url=http://XXX/cgi-bin/preset.sh?action=go_preset&num=1): [MissingHeaderBodySeparatorDefect()], unparsed data: 'PTZ_CMD_GOTO_POS pPtzInfo->nXPos=1448 ,pPtzInfo->nYPos=159\nContent-type: application/json\r\n\r\n'
```

To reproduce the issue without home assistant :

```
$ curl -vvv -u "XXXX:XXXX" "http://XXXXX/cgi-bin/preset.sh?action=go_preset&num=0"
* Host XXXXXXX was resolved.
* IPv6: (none)
* IPv4: X.X.X.X
*   Trying X.X.X.X:X..
* Connected to XXXXX (X.X.X.X) port X
* Server auth using Basic with user 'admin'
> GET /cgi-bin/preset.sh?action=go_preset&num=0 HTTP/1.1
> Host: XXXXX
> Authorization: Basic xxxx
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 200 OK
* Header without colon
* Closing connection
curl: (8) Header without colon
```

I found the culprit. For whatever reason, ptz binary do output something on stdout so I redirected the output to `/dev/null`.

```
[root@XXX]# ptz -f /mnt/mmc/sonoff-hack/etc/ptz_presets.conf -a go_preset -n 0
PTZ_CMD_GOTO_POS pPtzInfo->nXPos=1750 ,pPtzInfo->nYPos=1365
```

I also fixed a bash syntax error in the same file.
Maybe having `shellcheck` running in a github action would be a good idea, I can open another PR regarding this point (but this PR focuses on fixing the bug only)