### PR TITLE
Fixes saved PTZ presets forcing the tilt coordinate to the upper bound.

### DIFF
--- a/src/ptz/ptz/ptz.c
+++ b/src/ptz/ptz/ptz.c
@@ -553,7 +553,7 @@ int main(int argc, char **argv)
             if (x < MIN_X) x = MIN_X;
             if (x > MAX_X) x = MAX_X;
             if (y < MIN_Y) y = MIN_Y;
-            if (y < MAX_Y) y = MAX_Y;
+            if (y > MAX_Y) y = MAX_Y;
         }
 
         presets[preset_num].x = x;


### PR DESCRIPTION
`ACTION_SET_PRESET` clamps the current tilt position with `if (y < MAX_Y) y = MAX_Y`, which rewrites almost all valid Y positions to `MAX_Y` before saving. `go_preset` then sends that saved Y coordinate to the PTZ driver, causing numbered presets to restore pan correctly but drive tilt to the vertical limit.

 This changes the clamp to `if (y > MAX_Y) y = MAX_Y`, matching the existing `set_home` path.

EDIT: old presets need to be saved again after patch